### PR TITLE
Fix Word default format registry entry

### DIFF
--- a/configuration.xml
+++ b/configuration.xml
@@ -19,6 +19,6 @@
   <AppSettings>
     <User Key="software\microsoft\office\16.0\excel\options" Name="defaultformat" Value="51" Type="REG_DWORD" App="excel16" Id="L_SaveExcelfilesas" />
     <User Key="software\microsoft\office\16.0\powerpoint\options" Name="defaultformat" Value="27" Type="REG_DWORD" App="ppt16" Id="L_SavePowerPointfilesas" />
-    <User Key="software\microsoft\office\16.0\word\options" Name="defaultformat" Value="" Type="REG_SZ" App="word16" Id="L_SaveWordfilesas" />
+    <User Key="software\microsoft\office\16.0\word\options" Name="defaultformat" Value="16" Type="REG_DWORD" App="word16" Id="L_SaveWordfilesas" />
   </AppSettings>
 </Configuration>


### PR DESCRIPTION
## Summary
- correct the Word default save format configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a45a8d9868832ea55b16c3c18c21a9